### PR TITLE
Excluding object_literal rule as there is already discouraged_object_literal rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,7 +32,6 @@ opt_in_rules:
   - modifier_order
   - nimble_operator
   - nslocalizedstring_key
-  - object_literal
   - operator_usage_whitespace
   - overridden_super_call
   - override_in_extension


### PR DESCRIPTION
object_literal and discouraged_object_literal rules conflicting each other, hence only one should stay